### PR TITLE
Fix Todoist template expander workflow

### DIFF
--- a/workflows/19pwlUJok6EXe0uu.json
+++ b/workflows/19pwlUJok6EXe0uu.json
@@ -270,7 +270,8 @@
       "parameters": {
         "operation": "getAll",
         "returnAll": true,
-        "filters": {}
+        "filters": {},
+        "resource": "task"
       },
       "type": "n8n-nodes-base.todoist",
       "typeVersion": 2.1,
@@ -396,7 +397,9 @@
         "project": "={{$json.create.project}}",
         "labels": "={{$json.create.labels}}",
         "content": "={{$json.create.content}}",
-        "options": {}
+        "options": "={{$json.create.options}}",
+        "operation": "create",
+        "resource": "task"
       },
       "type": "n8n-nodes-base.todoist",
       "typeVersion": 2.1,


### PR DESCRIPTION
## Summary
- ensure the workflow fetches active tasks from the Todoist task resource before building template actions
- forward the prepared creation options when cloning template tasks so new tasks inherit their section and parent hierarchy

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68da4eb028608323908805479d18c9b1